### PR TITLE
Support reading GITHUB_TOKEN from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Prometheus GitHub Exporter
 
-Exposes basic metrics for your repositories from the GitHub API, to a Prometheus compatible endpoint. 
+Exposes basic metrics for your repositories from the GitHub API, to a Prometheus compatible endpoint.
 
 ## Configuration
 
 This exporter is setup to take input from environment variables:
 * `BIND_PORT` The port you wish to run the container on, defaults to `9171`
-* `GITHUB_TOKEN` If supplied, enables the user to supply a github authentication token that allows the API to be quried more often. Optional, but reccomended.
-* `ORGS` If supplied, the exporter will enumerate all repositories for that orginisation.
+* `GITHUB_TOKEN` If supplied, enables the user to supply a github authentication token that allows the API to be queried more often. Optional, but recommended.
+* `GITHUB_TOKEN_FILE` If supplied _instead of_ `GITHUB_TOKEN`, enables the user to supply a path to a file containing a github authentication token that allows the API to be queried more often. Optional, but recommended.
+* `ORGS` If supplied, the exporter will enumerate all repositories for that organization.
 * `REPOS` If supplied, The images you wish to monitor, expected in the format "user/repo1, user/repo2". Can be across different Github users/orgs.
 
 ## Install and deploy


### PR DESCRIPTION
It's beneficial sometimes to pass secrets (like an API token) in via a file, rather than an environment variable.

Also, this enables the use of the new secret management support in Docker Swarm mode in Docker 1.13.0 (https://docs.docker.com/engine/swarm/secrets/).

Signed-off-by: Dave Henderson <dhenderson@gmail.com>